### PR TITLE
attempt to fix wrong rect origin

### DIFF
--- a/VisionTest/Features/VisionOCR/Model/VisionRecognizedTextResult.swift
+++ b/VisionTest/Features/VisionOCR/Model/VisionRecognizedTextResult.swift
@@ -24,7 +24,7 @@ struct VisionRecognizedTextResult: Identifiable, Codable, Equatable {
 	let topRight: CGPoint
 	let bottomLeft: CGPoint
 	let bottomRight: CGPoint
-		
+
 	let boundingBox: CGRect
 	
 //	var subElements: [SubElement] = []
@@ -42,10 +42,10 @@ struct VisionRecognizedTextResult: Identifiable, Codable, Equatable {
 		self.string = candidate.string
 
 		self.bottomLeft = observation.bottomLeft
-		self.bottomRight = observation.bottomRight
+        self.bottomRight = observation.bottomRight
 		self.topRight = observation.topRight
 		self.topLeft = observation.topLeft
-		
+		        
 //		if let first = subElements.first, first.string == candidate.string {
 //			self.subElements = first.subElements
 //
@@ -53,8 +53,7 @@ struct VisionRecognizedTextResult: Identifiable, Codable, Equatable {
 //			self.subElements = subElements
 //		}
 		
-		let rect = CGRect(x: topLeft.x, y: topLeft.y, width: topRight.x - bottomLeft.x, height: bottomRight.y - topLeft.y)
-		
+		let rect = CGRect(x: topLeft.x, y: topLeft.y, width: topRight.x - bottomLeft.x, height: topRight.y - bottomLeft.y)
 //		if rect.height > 0 && rect.width > 0 {
 			self.boundingBox = rect
 //		}
@@ -79,7 +78,6 @@ struct VisionRecognizedTextResult: Identifiable, Codable, Equatable {
 	///Not sure if correct
 	func relativeBoundingBox(forImageFrame frame: CGRect) -> CGRect {
 		let r = CGRect(x: (topLeft.x * frame.width) + frame.minX, y: ((1 - topLeft.y) * frame.height) + frame.minY, width: boundingBox.width * frame.width, height: boundingBox.height * frame.height)
-//		print("Relative bounding box: \(r)")
 		return r
 	}
 	

--- a/VisionTest/Features/VisionOCR/View/TextRecognitionView.swift
+++ b/VisionTest/Features/VisionOCR/View/TextRecognitionView.swift
@@ -283,7 +283,7 @@ struct TextRecognitionView: View {
 			if imageRect != .zero {
 				ForEach(results.indices, id: \.self) { idx in
 					let rect = results[idx].relativeBoundingBox(forImageFrame: imageRect)
-					
+              
 					ElementView(element: Binding(get: {
 						if model.vpImage?.textDisplayResults.indices.contains(idx) ?? false {
 							return (model.vpImage?.textDisplayResults[idx])!
@@ -294,9 +294,9 @@ struct TextRecognitionView: View {
 					}), elementSelected: Binding(get: {
 						checkHighlightForResultIndex(idx, boundingBox: rect)
 					}, set: {_ in}), dragLocation: Binding(get: {
-						CGPoint(x: dragLocation.x - rect.minX, y: dragLocation.y - rect.minY)
+						CGPoint(x: dragLocation.x, y: dragLocation.y)
 					}, set: {_ in })
-					, selectedRange: $highlightedWords)
+					, selectedRange: $highlightedWords,elemBBox: rect)
 					.frame(width: rect.width, height: rect.height)
 					.position(x: rect.midX, y: rect.midY)
 					.background(

--- a/VisionTest/Features/VisionOCR/View/WordView.swift
+++ b/VisionTest/Features/VisionOCR/View/WordView.swift
@@ -21,12 +21,12 @@ struct WordView: View {
 		Text(word.string)
 			.font(Font(font))
 			.foregroundColor(.clear)
+            .background(word.string == "stress," ? Color.red.opacity(0.2) : Color.clear)
 			.frame(minWidth: size.width, maxHeight: size.height)
-			.border(Color.purple)
+            .border(Color.purple)
 			.onChange(of: dragLocation, perform: { value in
 				guard value != .zero else { return }
 				let h = word.boundingRect.contains(value)
-				
 				word.highlighted = h
 				if h {
 					highlightRangeInX(word, word.boundingRect.minX, word.boundingRect.maxX)


### PR DESCRIPTION
I think there were two problems:
1. When you divided up the element and use HStack to display each word, the `origin` of the `word` was relative to the `element`, that's why `origin.y` is always close to 0. But your drag position is relative to the whole image, so the `word rect` was unable to capture the drag point.
2. And you also need to offset each word with the total width of words before it to get the correct `origin.x` (I used a `totalWidth` variable to track that)